### PR TITLE
Fix build error on gcc 13.3

### DIFF
--- a/src/ui/PK2PaletteUtility.cpp
+++ b/src/ui/PK2PaletteUtility.cpp
@@ -183,7 +183,7 @@ void PK2PaletteUtility::showAboutDialog() {
 	QString aboutText = "<center><b>Pekka Kana 2 Palette Utility</b>";
 	aboutText += "<br />";
 	aboutText += "Version: ";
-	aboutText += VERSION_STRING;
+	aboutText += QString::fromUtf8(VERSION_STRING);
 	aboutText += "<hr />";
 	aboutText += "This project is open source:<br />";
 	aboutText += "<a href = \"https://github.com/Detea/PK2PaletteUtility\">https://github.com/Detea/PK2PaletteUtility</a></center>";


### PR DESCRIPTION
Fixed:
```
src/ui/PK2PaletteUtility.cpp:186:19: error: no match for ‘operator+=’ (operand types are ‘QString’ and ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’})
  186 |         aboutText += VERSION_STRING;
```